### PR TITLE
truncate long usernames in statuses/notes/posts/whatever

### DIFF
--- a/shared/src/commonMain/kotlin/site/remlit/snowdrop/component/MiniStatus.kt
+++ b/shared/src/commonMain/kotlin/site/remlit/snowdrop/component/MiniStatus.kt
@@ -47,23 +47,20 @@ fun MiniStatus(status: Status) {
 				Text(
 					status.account.displayName ?: status.account.username,
 					fontWeight = FontWeight.Bold,
-					maxLines = 1
+					maxLines = 1,
+					overflow = TextOverflow.Ellipsis,
+					modifier = Modifier.weight(1f)
 				)
 
 				Row(
-					modifier = Modifier.fillMaxWidth(),
-					horizontalArrangement = Arrangement.End
+					horizontalArrangement = Arrangement.spacedBy(5.dp),
+					verticalAlignment = Alignment.CenterVertically
 				) {
-					Row(
-						verticalAlignment = Alignment.CenterVertically,
-						horizontalArrangement = Arrangement.spacedBy(5.dp)
-					) {
-						Text(
-							"${status.getCreatedAtTimestamp()?.toRelativeString()}",
-							fontSize = 13.sp
-						)
-						Visibility(status.visibility)
-					}
+					Text(
+						"${status.getCreatedAtTimestamp()?.toRelativeString()}",
+						fontSize = 13.sp
+					)
+					Visibility(status.visibility)
 				}
 			}
 

--- a/shared/src/commonMain/kotlin/site/remlit/snowdrop/component/MiniStatus.kt
+++ b/shared/src/commonMain/kotlin/site/remlit/snowdrop/component/MiniStatus.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.jetbrains.compose.resources.painterResource

--- a/shared/src/commonMain/kotlin/site/remlit/snowdrop/component/Notification.kt
+++ b/shared/src/commonMain/kotlin/site/remlit/snowdrop/component/Notification.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.AnnotatedString
@@ -101,8 +102,8 @@ fun Notification(notification: Notification) {
 					}
 
 					Row(
-						modifier = Modifier.fillMaxWidth(),
-						horizontalArrangement = Arrangement.spacedBy(5.dp)
+						horizontalArrangement = Arrangement.spacedBy(5.dp),
+						verticalAlignment = Alignment.CenterVertically
 					) {
 						var displayName by remember { mutableStateOf("") }
 						var message by remember { mutableStateOf("") }
@@ -123,6 +124,8 @@ fun Notification(notification: Notification) {
 								else if (notification.status != null) "bit your post"
 								else "bit you"
 						}
+
+						val timestamp = "${notification.getCreatedAtTimestamp()?.toRelativeString()}"
 
 						/*
 						* Actually render the link and style it and all that stuff
@@ -155,7 +158,18 @@ fun Notification(notification: Notification) {
 							toAnnotatedString()
 						}
 
-						Text(title)
+						Text(
+							text = title,
+							modifier = Modifier.weight(1f),
+							maxLines = 1,
+							overflow = TextOverflow.Ellipsis
+						)
+
+						Text(
+							text = timestamp,
+							fontSize = 13.sp,
+							maxLines = 1
+						)
 					}
 				}
 

--- a/shared/src/commonMain/kotlin/site/remlit/snowdrop/component/Status.kt
+++ b/shared/src/commonMain/kotlin/site/remlit/snowdrop/component/Status.kt
@@ -168,25 +168,28 @@ fun Status(status: Status) {
 				}
 
 				Column(
-					modifier = Modifier.clickable(onClick = {
-						navHandler.navigate(ProfileRoute(realStatus.account.id))
-					})
+					modifier = Modifier.weight(1f)
+						.clickable(onClick = {
+							navHandler.navigate(ProfileRoute(realStatus.account.id))
+						})
 				) {
 					Text(
 						realStatus.account.displayName ?: realStatus.account.username,
 						fontWeight = FontWeight.Medium,
+						overflow = TextOverflow.Ellipsis,
+						maxLines = 1
 					)
 					Text(
 						"@${realStatus.account.fqn}",
 						overflow = TextOverflow.Ellipsis,
 						color = MaterialTheme.colorScheme.onSurfaceVariant,
-						fontSize = 13.sp
+						fontSize = 13.sp,
+						maxLines = 1
 					)
 				}
 
 				// todo: visiblity, timestamp, etc.
 				Column(
-					modifier = Modifier.fillMaxWidth(),
 					horizontalAlignment = Alignment.End
 				) {
 					Column(

--- a/shared/src/commonMain/kotlin/site/remlit/snowdrop/component/Status.kt
+++ b/shared/src/commonMain/kotlin/site/remlit/snowdrop/component/Status.kt
@@ -133,6 +133,7 @@ fun Status(status: Status) {
 			// todo: not vertically centered correctly
 		) {
 			if (isReblog && rebloggingAccount != null) {
+				val accountName = rebloggingAccount!!.displayName ?: rebloggingAccount!!.username
 				Row(
 					modifier = Modifier.padding(start = 35.dp),
 					verticalAlignment = Alignment.CenterVertically
@@ -144,10 +145,20 @@ fun Status(status: Status) {
 						tint = MaterialTheme.colorScheme.secondary
 					)
 					Text(
-						"${rebloggingAccount!!.displayName ?: rebloggingAccount!!.username} boosted",
+						accountName,
 						color = MaterialTheme.colorScheme.secondary,
 						fontSize = 14.sp,
-						fontWeight = FontWeight.Medium
+						fontWeight = FontWeight.Medium,
+						maxLines = 1,
+						overflow = TextOverflow.Ellipsis,
+						modifier = Modifier.weight(1f)
+					)
+					Text(
+						" boosted",
+						color = MaterialTheme.colorScheme.secondary,
+						fontSize = 14.sp,
+						fontWeight = FontWeight.Medium,
+						maxLines = 1
 					)
 				}
 			}

--- a/shared/src/commonMain/kotlin/site/remlit/snowdrop/component/Status.kt
+++ b/shared/src/commonMain/kotlin/site/remlit/snowdrop/component/Status.kt
@@ -133,34 +133,37 @@ fun Status(status: Status) {
 			// todo: not vertically centered correctly
 		) {
 			if (isReblog && rebloggingAccount != null) {
-				val accountName = rebloggingAccount!!.displayName ?: rebloggingAccount!!.username
-				Row(
-					modifier = Modifier.padding(start = 35.dp),
-					verticalAlignment = Alignment.CenterVertically
-				) {
-					Icon(
-						painterResource(Res.drawable.icon_repeat_24px),
-						null,
-						modifier = Modifier.padding(end = 5.dp),
-						tint = MaterialTheme.colorScheme.secondary
-					)
-					Text(
-						accountName,
-						color = MaterialTheme.colorScheme.secondary,
-						fontSize = 14.sp,
-						fontWeight = FontWeight.Medium,
-						maxLines = 1,
-						overflow = TextOverflow.Ellipsis,
-						modifier = Modifier.weight(1f)
-					)
-					Text(
-						" boosted",
-						color = MaterialTheme.colorScheme.secondary,
-						fontSize = 14.sp,
-						fontWeight = FontWeight.Medium,
-						maxLines = 1
-					)
-				}
+						Row(
+							modifier = Modifier.padding(start = 35.dp),
+							verticalAlignment = Alignment.CenterVertically
+						) {
+							Icon(
+								painterResource(Res.drawable.icon_repeat_24px),
+								null,
+								modifier = Modifier.padding(end = 5.dp),
+								tint = MaterialTheme.colorScheme.secondary
+							)
+							Row(
+								modifier = Modifier.weight(1f, fill = false),
+								verticalAlignment = Alignment.CenterVertically
+							) {
+								Text(
+									rebloggingAccount!!.displayName ?: rebloggingAccount!!.username,
+									color = MaterialTheme.colorScheme.secondary,
+									fontSize = 14.sp,
+									fontWeight = FontWeight.Medium,
+									overflow = TextOverflow.Ellipsis,
+									maxLines = 1,
+									modifier = Modifier.weight(1f, fill = false)
+								)
+								Text(
+									" boosted",
+									color = MaterialTheme.colorScheme.secondary,
+									fontSize = 14.sp,
+									fontWeight = FontWeight.Medium
+								)
+							}
+						}
 			}
 
 			// Header


### PR DESCRIPTION
works fine on statuses but i wanna get it to work on boosts too. 

![IMG_20260625_161739.jpg](https://github.com/user-attachments/assets/bb4fae63-3257-4a20-a119-ad7997dab571)

![IMG_20260625_170900.jpg](https://github.com/user-attachments/assets/48cee914-e3c2-459f-97c3-6d48bcfb3f20)


