### PR TITLE
fix(i18n): use Joined on instead of Joined at for English dates

### DIFF
--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -20,7 +20,7 @@
 	<string name="follow">Follow</string>
 	<string name="unfollow">Unfollow</string>
 
-	<string name="joined_at_x">Joined at {date_time}</string>
+	<string name="joined_at_x">Joined on {date_time}</string>
 
 	<string name="x_followers">{count} followers</string>
 	<string name="x_following">{count} following</string>


### PR DESCRIPTION
## Summary

English copy \"Joined at {date_time}\" is unidiomatic for calendar dates.
Change to \"Joined on {date_time}\" per #120.

Only the default English `values/strings.xml` is updated (other locales already use natural phrasing).

Fixes #120